### PR TITLE
Add a step for creating the instance profile

### DIFF
--- a/labs/03-beanstalk/README.md
+++ b/labs/03-beanstalk/README.md
@@ -36,6 +36,15 @@ aws iam attach-role-policy --policy-arn arn:aws:iam::aws:policy/AmazonDynamoDBFu
 --role-name aws-elasticbeanstalk-ec2-role
 ```
 
+### Create Instance Profile
+
+Create the intsance profile and add the `aws-elasticbeanstalk-ec2-role` role we created earlier.
+
+```bash
+aws iam create-instance-profile --instance-profile-name aws-elasticbeanstalk-ec2-role
+aws iam add-role-to-instance-profile --instance-profile-name aws-elasticbeanstalk-ec2-role --role-name aws-elasticbeanstalk-ec2-role
+```
+
 ## Create Elastic Beanstalk Application
 
 Create an Elastic Beanstalk Application that will house the two environments - Prod and QA


### PR DESCRIPTION
*Issue description:*
In lab 03, creating an environment with the below command fails because the instance profile has not yet been created as described in the AWS documentation over here [Getting Started - Create IAM Instance Profile](https://docs.aws.amazon.com/codedeploy/latest/userguide/getting-started-create-iam-instance-profile.html)

```bash
aws elasticbeanstalk create-environment \
--application-name VLS \
--environment-name [your-prod-env-name] \
--cname-prefix [your-preferred-cname] \
--solution-stack-name "64bit Amazon Linux 2 v5.3.0 running Node.js 12" \
--option-settings Namespace=aws:autoscaling:launchconfiguration,OptionName=IamInstanceProfile,Value="aws-elasticbeanstalk-ec2-role"
```

*Description of changes:*

Modified the lab 03 documentation to include a step that creates the instance profile from the service role that was created
in the readme

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
